### PR TITLE
Add method for path prefix sanitization

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -303,4 +303,21 @@ class File
         $str = str_replace('%', '-', $str);
         return $str;
     }
+
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
+    public static function sanitizePathPrefix(string $path): string {
+        $pattern = '/.*:\/\//i';
+
+        $path = preg_replace($pattern, '', $path);
+
+        if (preg_match($pattern, $path)) {
+            return self::sanitizePathPrefix($path);
+        }
+
+        return $path;
+    }
 }


### PR DESCRIPTION
This method is the first part of a fix for [this issue](https://github.com/AzuraCast/AzuraCast/issues/1479) from the AzuraCast repository.

The method is calling itself recursively to sanitize malicious strings that include the filesystem prefix in such a way that after removing normal occurrences of that pattern the remaining characters add up to the prefix thus circumventing a single sanitization. (I hope that sentence wasn't too convoluted 😅)